### PR TITLE
Explain that how the Last-Modified header is used

### DIFF
--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -47,6 +47,8 @@ module Puppet
       The `http` source uses the server `Content-MD5` header as a checksum to
       determine if the remote file has changed. If the server response does not
       include that header, Puppet defaults to using the `Last-Modified` header.
+      Puppet will update the local file if the header is newer than the modified
+      time (mtime) of the local file.
 
       Multiple `source` values can be specified as an array, and Puppet will
       use the first source that exists. This can be used to serve different


### PR DESCRIPTION
In the file resource, attribute source, for the local file to be replaced, the `Last-Modified` header needs to be greater than modified time of local file, unlike the `Content-MD5` header that only needs to be different from local file's MD5.